### PR TITLE
Update deprecated Stan syntax

### DIFF
--- a/inst/stan/linelist.stan
+++ b/inst/stan/linelist.stan
@@ -71,16 +71,16 @@ data {
   // OBSERVED
   int<lower=1>     N_obs;           // Number of individuals
   matrix[N_obs, J] dum_obs;         // matrix of indicator values
-  int              Y_obs[N_obs];    // observed reporting delays
-  int              ReportOnset[N_obs]; // which days did these occur on ...
+  array[N_obs] int Y_obs;    // observed reporting delays
+  array[N_obs] int ReportOnset; // which days did these occur on ...
 
   // MISSING
   int<lower=1>      N_miss;        // Number of individuals with missing data
   matrix[N_miss, J] dum_miss;      // matrix of indicator values
-  int               ReportDays[N_miss]; // which days were things reported on
+  array[N_miss] int ReportDays; // which days were things reported on
 
   // Tells you the true order of cases
-  int  missvector[N_obs + N_miss];
+  array[N_obs + N_miss] int missvector;
 }
 
 

--- a/inst/stan/stan_sliding_v4.stan
+++ b/inst/stan/stan_sliding_v4.stan
@@ -1,9 +1,9 @@
 data {
   int<lower=1> N;          // the number of observations.
   int<lower=1> NW;         // the number of weeks.
-  int week_vec[N];         // the week vector
+  array[N] int week_vec;         // the week vector
   int<lower=1> J;          // the number of regions
-  int<lower=0> Y[N,J];     // observed cases.
+  array[N,J] int<lower=0> Y;     // observed cases.
   matrix[N*J,J] P;         // transfer matrix, changes with time
   int<lower=1> S;          // length of serial interval
   vector[S] W;             // serial interval

--- a/inst/stan/stan_sliding_v4nc1.stan
+++ b/inst/stan/stan_sliding_v4nc1.stan
@@ -1,9 +1,9 @@
 data {
   int<lower=1> N;          // the number of observations. 
   int<lower=1> NW;         // the number of weeks. 
-  int week_vec[N];         // the week vector 
+  array[N] int week_vec;         // the week vector 
   int<lower=1> J;          // the number of regions
-  int<lower=0> Y[N,J];     // observed cases. 
+  array[N,J] int<lower=0> Y;     // observed cases. 
   matrix[N*J,J] P;         // transfer matrix, changes with time
   int<lower=1> S;          // length of serial interval
   vector[S] W;             // serial interval


### PR DESCRIPTION
This PR updates the deprecated array syntax used in your Stan models, otherwise it will fail to install with future versions of RStan. Thanks!